### PR TITLE
Disallow removal of CICD Permission boundary and add missing permission for self-mutate

### DIFF
--- a/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
+++ b/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
@@ -1,14 +1,10 @@
 # This template is modified from original to add PermissionsBoundary for CFN Execution Role
-# The CFN Excution Role usually has AdministratorAccess attached. This exposes the CICD account to risk as
-# anyone who can execute `cdk deploy` can create role with any access (IAM privilege escalation)
+# The CFN Execution Role usually has AdministratorAccess attached. This exposes the CICD account to risk as
+# anyone who can execute `cdk deploy` can create role with AdministratorAccess (IAM privilege escalation)
 #
-# We create two PermissionsBoundaries to avoid privilege escalation.
-# 1. CloudFormationExecutionPermissionsBoundary
-# 2. CICDPipelinePermissionsBoundary
-#
-# We need two separated permissions boundaries because pipelines created by cdk-pipeline package can SelfMutate.
-# Thus, it must be able to delete the boundary. We allows it to delete CICDPipelinePermissionsBoundary, but not
-# CloudFormationExecutionPermissionsBoundary to prevent privilege escalation.
+# We create two PermissionsBoundaries to with least privilege policy.
+# 1. CloudFormationExecutionPermissionsBoundary - for CICD pipeline deployment
+# 2. CICDPipelinePermissionsBoundary - for any roles used in CICD pipeline (e.g. CodeBuild/CodePipeline)
 #
 # See the following links for more details:
 # 1. https://aws.amazon.com/premiumsupport/knowledge-center/iam-permission-boundaries/
@@ -18,8 +14,6 @@
 # Original Bootstrap template (used when you run `cdk bootstrap`):
 # https://github.com/aws/aws-cdk/blob/master/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
 #
-# The created policy for PermissionsBoundary contains least privilege policy for creating
-# a pipeline with CDK Pipelines Module (https://docs.aws.amazon.com/cdk/api/latest/docs/pipelines-readme.html)
 Description: This stack includes resources needed to deploy AWS CDK apps into this
   environment
 Parameters:
@@ -424,7 +418,7 @@ Resources:
               - s3:GetEncryptionConfiguration
               - s3:PutEncryptionConfiguration
             Resource:
-              - "*"
+              - !Sub "arn:aws:s3:::*"
           - Effect: Allow
             Action:
               - codepipeline:CreateCustomActionType
@@ -451,7 +445,7 @@ Resources:
           - Effect: Allow
             Action:
               - secretsmanager:GetSecretValue
-            Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*"
+            Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:GITHUB_TOKEN*"
 
             # KMS
           - Effect: Allow
@@ -489,6 +483,12 @@ Resources:
               - codebuild:BatchGetProjects
             Resource: !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/*"
 
+          # Self-Mutate requires permission to start PipelineExecution
+          - Effect: Allow
+            Action:
+              - codepipeline:StartPipelineExecution
+            Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
+
             # IamReadPolicyForKMSKeyCreation
           - Effect: Allow
             Action:
@@ -522,17 +522,6 @@ Resources:
               - sts:AssumeRole
             Resource: "*"
 
-            # AlloBoundaryDeletionForCICDSelfMutate
-          - Effect: Allow
-            Action:
-              - iam:DeleteRolePermissionsBoundary
-            Resource:
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/*"
-            Condition:
-              "StringEquals":
-                "iam:PermissionsBoundary":
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:policy/cdk-${Qualifier}-cicd-pipeline-permissions-boundary-policy-${AWS::AccountId}-${AWS::Region}"
-
           ##################################################################
           # Deny dangerous actions that could escalate privilege or cause security incident
           ##################################################################
@@ -565,7 +554,7 @@ Resources:
               "ForAnyValue:StringEquals":
                 "iam:PermissionsBoundary":
                   - !Sub "arn:aws:iam::${AWS::AccountId}:policy/cdk-${Qualifier}-cfn-exec-permissions-boundary-policy-${AWS::AccountId}-${AWS::Region}"
-                  # Pipeline is self-mutate and it uses this role to delete/update CICD permissions boundary
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:policy/cdk-${Qualifier}-cicd-pipeline-permissions-boundary-policy-${AWS::AccountId}-${AWS::Region}"
 
             # DenyBoundaryUpdateIfNotAddingBoundary
           - Effect: Deny


### PR DESCRIPTION
*Description of changes:*

Currently, CFN Exec role can remove CICD permission boundary. Malicious users could create a CI/CD with that boundary and remove it when update.  Thus, I remove this permission and tested that the self-mutation still works if it doesn't remove  the role's permission boundary.

Also, I add the permission to start pipeline execution as it's required in self-mutation step. If users do not try to remove permission boundary, the self-mutation works. (See "Testing methods" for more details)

*Testing methods:*
1. Tested that the pipeline can self-mutate if we have StartExecution for CodePipeline.  The case that mutation fails is only when we remove permission boundary or the roles. In that case, they must use admin account to change the stack directly. If users just add/remove stage, it still works fine.  
2. The permission boundary allows UpdateRole * but deny boundary deletion. I have tested creating a role and tried to remove it via CDK. I get permission denied as expected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
