### PR TITLE
fix(ssm:GetParameter): Transpose V5 cdk bootstrap-template

### DIFF
--- a/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
+++ b/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
@@ -183,6 +183,7 @@ Resources:
             RestrictPublicBuckets: true
           - Ref: AWS::NoValue
     UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
   StagingBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
     Properties:
@@ -368,6 +369,12 @@ Resources:
                   - sts:GetCallerIdentity
                 Resource: "*"
                 Effect: Allow
+              - Sid: ReadVersion
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource:
+                  - Fn::Sub: "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${CdkBootstrapVersion}"
             Version: '2012-10-17'
           PolicyName: default
       RoleName:
@@ -701,7 +708,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: '/cdk-bootstrap/${Qualifier}/version'
-      Value: 4
+      Value: '5'
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack


### PR DESCRIPTION
…-bootstrap-kit template

*Issue #, if available:*
This PR references the following issue: [#34 - ssm:GetParameter fails](https://github.com/aws-samples/aws-bootstrap-kit-examples/issues/34)
*Description of changes:*

- Transposed "v5" bootstrap-template.yaml from: [aws-cdk/packages/aws-cdk/lib/api/bootstrap/](https://github.com/aws/aws-cdk/blob/master/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml)

**Note:** The additional permission boundaries used in this repository (aws-bootstrap-kit-examples) have been preserved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
