### PR TITLE
fix: force deps between config and site deployment

### DIFF
--- a/source/5-unicornPics/backend/lib/frontend/frontend-config.ts
+++ b/source/5-unicornPics/backend/lib/frontend/frontend-config.ts
@@ -35,7 +35,7 @@ export class FrontendConfig extends cdk.Construct {
       },
     });
 
-    new cr.AwsCustomResource(this, 'WriteS3ConfigFile', {
+    const configDeployment = new cr.AwsCustomResource(this, 'WriteS3ConfigFile', {
       onUpdate: {
         service: 'S3',
         action: 'putObject',
@@ -50,6 +50,8 @@ export class FrontendConfig extends cdk.Construct {
         resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
       }),
     });
+
+    configDeployment.node.addDependency(props.frontend.siteDeployment);
 
     new cdk.CfnOutput(this, 'frontendConfig', {
         value: this.config

--- a/source/5-unicornPics/backend/lib/frontend/frontend.ts
+++ b/source/5-unicornPics/backend/lib/frontend/frontend.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 export class Frontend extends cdk.Construct {
   public readonly activateBucket: s3.Bucket;
   public readonly activateDistribution: cloudfront.Distribution;
+  public readonly siteDeployment: s3deploy.BucketDeployment;
 
   constructor(scope: cdk.Construct, id: string) {
     super(scope, id);
@@ -44,7 +45,7 @@ export class Frontend extends cdk.Construct {
       ]
     }); 
 
-    new s3deploy.BucketDeployment(this, 'DeployWithInvalidation', {
+    this.siteDeployment = new s3deploy.BucketDeployment(this, 'DeployWithInvalidation', {
       sources: [
         s3deploy.Source.asset(path.resolve(__dirname, '../../../webapp/build')),
       ],


### PR DESCRIPTION
This PR force the config deployment to wait for the website to be completely deployed to ensure proper overriding of config.json.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
