### PR TITLE
Fix error 403 when refreshing the /home and /profile page. 

### DIFF
--- a/source/5-unicornPics/backend/lib/frontend/frontend.ts
+++ b/source/5-unicornPics/backend/lib/frontend/frontend.ts
@@ -28,6 +28,7 @@ export class Frontend extends cdk.Construct {
         defaultRootObject: 'index.html',
         errorResponses: [
           { httpStatus: 404, responsePagePath: '/index.html', responseHttpStatus: 200 },
+          { httpStatus: 403, responsePagePath: '/index.html', responseHttpStatus: 200 },
         ],
       }
     );


### PR DESCRIPTION
Added a 403 error page to CloudFront distribution.

*Issue #, if available:*

Refreshing the page on /home and /profile is returning a 403 error from CloudFront. 

*Description of changes:*

Added a new Error page to the CloudFront distribution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
