### PR TITLE
Implement target CDK environment deployment check

### DIFF
--- a/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
+++ b/source/1-SDLC-organization/lib/cdk-bootstrap-template.yml
@@ -745,6 +745,10 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource: "*"
 
           ##################################################################
           # Deny dangerous actions that could escalate privilege or cause security incident

--- a/source/3-landing-page-cicd/cdk/bin/landing-page.ts
+++ b/source/3-landing-page-cicd/cdk/bin/landing-page.ts
@@ -9,7 +9,11 @@ const app = new cdk.App();
 // Use for direct deploy to an environment without pipeline
 new LandingPageStage(app, 'Test', {});
 // Use to deploy the pipeline stack
-const pipelineStack = new LandingPagePipelineStack(app, 'LandingPageStackPipeline');
+const pipelineStack = new LandingPagePipelineStack(app, 'LandingPageStackPipeline', {
+    env: {
+        region: process.env.CDK_DEFAULT_REGION,
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+    } });
 
 const permissionBoundaryArn = cdk.Fn.importValue('CICDPipelinePermissionsBoundaryArn')
 

--- a/source/3-landing-page-cicd/cdk/lib/cicd-stack.ts
+++ b/source/3-landing-page-cicd/cdk/lib/cicd-stack.ts
@@ -124,7 +124,7 @@ export class LandingPagePipelineStack extends Stack{
     }
 
     private async CheckTargetEnvironments(accounts: Iterable<string>, region: string, qualifier: string) : Promise<void> {
-        var stsClient = new STS();
+        const stsClient = new STS();
 
         for (const account of accounts) {
             console.log(`Checking whether the target environment aws://${account}/${region} is deployable...`);

--- a/source/3-landing-page-cicd/cdk/lib/cicd-stack.ts
+++ b/source/3-landing-page-cicd/cdk/lib/cicd-stack.ts
@@ -129,7 +129,7 @@ export class LandingPagePipelineStack extends Stack{
         for (const account of accounts) {
             console.log(`Checking whether the target environment aws://${account}/${region} is deployable...`);
             if (!await this.checkTargetEnvironment(stsClient, account, region, qualifier)) {
-                var message = `Account ${account} is not bootstrapped in ${region}. Make sure you deploy the pipeline in a deployable region.`;
+                const message = `Account ${account} is not bootstrapped in ${region}. Make sure you deploy the pipeline in a deployable region.`;
                 throw new Error(message);
             }
         }


### PR DESCRIPTION
*Issue:* #149 

*Description of changes:*
This fix addresses the scenario when the CI/CD pipeline landing page stack is about to be deployed into a region that was not configured as 'deployable' in the SDLC Organization setup (that means, this region might not be bootstrapped correctly).

In this scenario, the deployment should not be allowed.

In #149, we consider two possible options. This PR implements the first option: if the target environment is not bootstrapped, the deployment aborts.

The checks will be performed in the CDK code itself, not in the deployed stack. This allows us to bail out as soon as possible without even creating a change set.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
