### PR TITLE
Rename SSO to IAM Identity Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
 # AWS Bootstrap Kit Examples Overview
 
 - [AWS Bootstrap Kit Examples Overview](#aws-bootstrap-kit-examples-overview)
-  * [Who is this for?](#who-is-this-for)
-  * [What you will get with it?](#what-you-will-get-with-it)
-    + [As an Operator](#as-an-operator)
-    + [As a developer](#as-a-developer)
-    + [As a developer oncall](#as-a-developer-oncall)
-  * [What you will get with it? (the AWS infrastructure)](#what-you-will-get-with-it-the-aws-infrastructure)
-  * [Getting started](#getting-started)
-  * [Tenets](#tenets)
-  * [What you will find in this repository](#what-you-will-find-in-this-repository)
-  * [What you won't find in this repository](#what-you-wont-find-in-this-repository)
-  * [Do I need to be familiar with the AWS Services used under the hood?](#do-i-need-to-be-familiar-with-the-aws-services-used-under-the-hood)
-  * [Concept](#concept)
-    + [Infrastructure as Code](#infrastructure-as-code)
-    + [CI/CD](#cicd)
-    + [Multi accounts strategy](#multi-accounts-strategy)
-    + [DNS hierarchy](#dns-hierarchy)
-  * [Security](#security)
-    + [Control deployment](#control-deployment)
-    + [Control access to AWS](#control-access-to-aws)
-    + [Minimal security best practices](#minimal-security-best-practices)
-  * [Costs](#costs)
-  * [Cleaning up accounts](#cleaning-up-accounts)
-  * [Known limitations](#known-limitations)
-    + [SDLC Organization](#sdlc-organization)
+  - [Who is this for?](#who-is-this-for)
+  - [What you will get with it?](#what-you-will-get-with-it)
+    - [As an Operator](#as-an-operator)
+    - [As a developer](#as-a-developer)
+    - [As a developer oncall](#as-a-developer-oncall)
+  - [What you will get with it? (the AWS infrastructure)](#what-you-will-get-with-it-the-aws-infrastructure)
+  - [Getting started](#getting-started)
+  - [Tenets](#tenets)
+  - [What you will find in this repository](#what-you-will-find-in-this-repository)
+  - [What you won't find in this repository](#what-you-wont-find-in-this-repository)
+  - [Do I need to be familiar with the AWS Services used under the hood?](#do-i-need-to-be-familiar-with-the-aws-services-used-under-the-hood)
+  - [Concept](#concept)
+    - [Infrastructure as Code](#infrastructure-as-code)
+    - [CI/CD](#cicd)
+    - [Multi accounts strategy](#multi-accounts-strategy)
+    - [DNS Hierarchy](#dns-hierarchy)
+  - [Security](#security)
+    - [Control deployment](#control-deployment)
+    - [Control access to AWS](#control-access-to-aws)
+    - [Minimal security best practices](#minimal-security-best-practices)
+  - [Costs](#costs)
+  - [Cleaning up accounts](#cleaning-up-accounts)
+  - [Known limitations](#known-limitations)
+    - [SDLC Organization](#sdlc-organization)
+  - [Getting Help](#getting-help)
+  - [Next](#next)
 
 This repository contains examples of using the AWS Bootstrap Kit to set your development and deployment environment on AWS. The AWS Bootstrap Kit is a strongly opinionated CDK set of constructs built for companies looking to follow AWS best practices on Day 1.
 
@@ -79,8 +81,8 @@ DNS hierarchy:
 Basically the same as above but:
 * Environments = [AWS Accounts](https://aws.amazon.com/organizations/faqs/#Organizing_AWS_accounts) (not a *user* account but actually a isolated environment tied to an email (& password) and unique id)
 * Set of Environments = Set of AWS Accounts under a main one = [AWS Organizations](https://aws.amazon.com/organizations/faqs/)
-* Users and Permissions management solution = [AWS SSO](https://aws.amazon.com/single-sign-on/faqs)
-* Login Web Portal = AWS SSO endpoint
+* Users and Permissions management solution = [AWS IAM Identity Center](https://aws.amazon.com/single-sign-on/faqs)
+* Login Web Portal = AWS access portal URL
 * Central Activity logs = Centralized [AWS Cloudtrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html)
 * Central Bills = [AWS Consolidated Billing](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/consolidated-billing.html)
 * CI/CD Pipeline = [AWS CodePipeline](https://aws.amazon.com/codepipeline)
@@ -174,7 +176,7 @@ You will see that manual approvals are added by default in CI/CD pipelines givin
 
 ### Control access to AWS
 
-Going with AWS SSO will enforce temporary credentials usage while simplifying developers environment setup.
+Going with AWS IAM Identity Center will enforce temporary credentials usage while simplifying developers environment setup.
 
 ### Minimal security best practices
 

--- a/doc/control-tower.md
+++ b/doc/control-tower.md
@@ -1,12 +1,12 @@
 # Path to AWS Control Tower
 
-[AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html) provides an easy way to setup a Landing Zone in AWS: it will create a multi-account structure with proper set of permissions (using [AWS SSO](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)) and guardrails (using [Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) (SCPs) and [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)).
+[AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html) provides an easy way to setup a Landing Zone in AWS: it will create a multi-account structure with proper set of permissions (using [AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)) and guardrails (using [Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) (SCPs) and [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)).
 
 Control Tower focuses on providing a secured multi-accounts environment. It creates multiples AWS resources for you:
 - One Organization
 - One or two Organizational Units (OUs): Security (mandatory) and Sandbox (optional)
 - Two AWS Accounts in the Security OU: Log Archive and Audit
-- A directory in AWS SSO
+- A directory in AWS IAM Identity Center
 - A set of guardrails: proactive with SCPs and reactive with AWS Config.
 - ...
 You can get more details on Control Tower [here](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html).
@@ -176,4 +176,4 @@ Control Tower is now set up and governs the Bootstrap Kit resources (Org, OUs, a
 
 Note that the Administrator user now has the following permissions: [AWSOrganizationsFullAccess](https://github.com/SummitRoute/aws_managed_policies/blob/master/policies/AWSOrganizationsFullAccess) on the bootstrap kit accounts (instead of AWSAdministratorAccess). See [docs](https://docs.aws.amazon.com/controltower/latest/userguide/sso.html):
 
-![Administrator permissions in SSO portal](migration-ct-admin-permissions.png)
+![Administrator permissions in AWS access portal](migration-ct-admin-permissions.png)

--- a/source/1-SDLC-organization/README.md
+++ b/source/1-SDLC-organization/README.md
@@ -15,7 +15,7 @@ Step # | Feature | Description
 2 | [Configure your local credentials](#configure-your-local-credentials) | `aws configure --profile main-admin`
 3 | [Fork and init the repo](#clone-and-init-the-repo) | Get the code
 4 | [Deploy the pipeline](#install-dependencies-and-deploy-the-pipeline) | Deploy your organization through a CI/CD pipeline
-5 | [Setup your SSO domain](#setup-your-sso-domain) | Prepare you user permissions and groups
+5 | [Setup your IAM Identity Center domain](#setup-your-sso-domain) | Prepare you user permissions and groups
 6 | [Setup your dev environment](#setup-your-dev-environment) | Prepare your local environment to be ready to develop
 7 | [Start coding](#next-step) | Jump to next section about developing and deploying your first web site
 
@@ -283,15 +283,15 @@ If you added `domain_name` in your config file (`cdk.json`) earlier, a last step
 **Your Done! Now you can manage your domain through AWS Route53**
 </details>
 
-### Enable SSO
+### Enable IAM Identity Center
 
-In order to facilitate the management of permissions on the access to this different accounts we suggest to setup an SSO portal following the steps described bellow. That's going to give you the capability to centrally manage and access your different AWS account with a single identity (login and password) or even delegate this to a third party provider such as Google Workspace (GSuite).
+In order to facilitate the management of permissions on the access to this different accounts we suggest to setup an AWs access portal following the steps described bellow. That's going to give you the capability to centrally manage and access your different AWS account with a single identity (login and password) or even delegate this to a third party provider such as Google Workspace (GSuite).
 
 Staying with IAM users and groups would means not getting a central portal with a single identity and would force you to remember the different account ID and role to login into:
 
 
 
-![A diagram showing IAM sign in page versus SSO one](../../doc/sign-in-iam-vs-sso.png)
+![A diagram showing IAM sign in page versus AWS access portal one](../../doc/sign-in-iam-vs-sso.png)
 
 
 *Whatch this quick presentation video to learn more:*
@@ -300,7 +300,7 @@ Staying with IAM users and groups would means not getting a central portal with 
     <img src="https://img.youtube.com/vi/_qNkFxp1Z_k/hqdefault.jpg"  alt="AWS Single Sign On video"/>
 </a>
 
-### Setup your SSO domain
+### Setup your IAM Identity Center domain
 
 <details>
 <summary>Click to go through this step</summary>
@@ -308,7 +308,7 @@ Staying with IAM users and groups would means not getting a central portal with 
 Sorry we can't automate those step yet :cry:
 
 
-1. Go to the <a href="https://console.aws.amazon.com/singlesignon/home" target="_blank">AWS SSO Home page</a> and  Click *Enable AWS SSO*
+1. Go to the <a href="https://console.aws.amazon.com/singlesignon/home" target="_blank">AWS IAM Identity Center Home page</a> and  Click *Enable*
 
 #### Create permission sets
 
@@ -504,7 +504,7 @@ Now we are going to assign the **Administrators** group to all the accounts with
 
 **Now let's create your Administrator user !**
 
-#### Create your administrator SSO user
+#### Create your administrator user
 
 
 
@@ -526,27 +526,27 @@ Now we are going to create an Administrator user, we basically will follow the s
 
 1. Well done your account has been successfully activated! Click *Continue*
 
-1. You have now access to your SSO app list. Click on *AWS Account* card to expand the list of accounts
+1. You have now access to your app list. Click on *AWS Account* card to expand the list of accounts
 
 1. Click on your main account to expand the list of your access to this account
 
 1. Click on *Management console* to access to the console of your main account
 
-1. Your are now connected with your new SSO Administrator user
+1. Your are now connected with your new Administrator user
 
-**Let's assign the Developers group to Dev, Staging and Prod accounts with this new SSO Administrator user**
+**Let's assign the Developers group to Dev, Staging and Prod accounts with this new Administrator user**
 
-#### Customize your SSO endpoint
+#### Customize your AWS access portal URL
 
-From now on, you or any of your developers won't have to login anymore directly to AWS console but directly through AWS SSO portal. In the previous step you might have noticed that your SSO console is accessible through a unique URL such as `https://d-123456789a.awsapps.com/start ` which is not that easy to remember, let's customize it to match your company domain:
+From now on, you or any of your developers won't have to login anymore directly to AWS console but directly through AWS access portal. In the previous step you might have noticed that your AWS user portal is accessible through a unique URL such as `https://d-123456789a.awsapps.com/start ` which is not that easy to remember, let's customize it to match your company domain:
 
-1. Search for *SSO* on the console home page and go to the service
+1. Search for *Identity Center* on the console home page and go to the service
 
 1. At the bottom of the page, click the *Customize* link located in *User portal* section
 
 1. Type your domain name and click *Save*
 
-**Tada !! You can now login to AWS Console through your SSO portal using your customized url !**
+**Tada !! You can now login to AWS Console through your AWS access portal using your customized url !**
 
 </details>
 
@@ -555,7 +555,7 @@ From now on, you or any of your developers won't have to login anymore directly 
 <details>
 <summary>Click to go through this step</summary>
 
-#### Create a developer SSO user
+#### Create a developer user
 
 (This section is optional but will be one to use each time you want to onboard a new dev in your team)
 
@@ -577,7 +577,7 @@ Now we are going to create a Developer user with enough rate to develop and publ
 
 1. Well done your account has been successfully activated! Click *Continue*
 
-1. You have now access to your SSO app list with your Developer user
+1. You have now access to your app list with your Developer user
 
 
 #### AWS CLI V2
@@ -606,7 +606,7 @@ aws sso login --profile dev
 
 In order to interact with your different environment through the [awscli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) or any AWS SDKs locally, you will need to get your credentials.
 
-To authenticate requests made using the CLI, we need to give the credentials generated by AWS SSO and link them to what we call `profile`. So for each environment you want to have access to through AWS CLI v2 and CDK you will have to configure a specific profile for it running the command below.
+To authenticate requests made using the CLI, we need to give the credentials generated by AWS IAM Identity Center and link them to what we call `profile`. So for each environment you want to have access to through AWS CLI v2 and CDK you will have to configure a specific profile for it running the command below.
 
 Here we setup your first profile that will be used to replace your IAM user administrator one (`--profile dev`):
 
@@ -667,9 +667,9 @@ aws sso login --profile dev
 
 **Now you can interact with your different AWS Accounts using AWS CLI**
 
-#### CDK and SSO
+#### CDK and IAM Identity Center
 
-CDK and AWS SSO are not yet friends (see github issue [5455](https://github.com/aws/aws-cdk/issues/5455)). So since in the future we will have to deploy infrastructure as code apps into multiple environment, we  will need to make it work.
+CDK and AWS IAM Identity Center are not yet friends (see github issue [5455](https://github.com/aws/aws-cdk/issues/5455)). So since in the future we will have to deploy infrastructure as code apps into multiple environment, we  will need to make it work.
 
 There is several workaround and here is one using a quick utility written in nodejs called "cdk-sso-sync":
 

--- a/source/2-landing-page/README.md
+++ b/source/2-landing-page/README.md
@@ -84,7 +84,7 @@ As you can see in the [code](../lib/landing-page-stack.ts#L44), the public url w
     cdk deploy --profile dev
     ```
 
-    > If you get the error message *Unable to resolve AWS account to use. It must be either configured when you define your CDK or through the environment*, you may need to refresh your SSO credentials by running the SSO login command described [here](../1-SDLC-organization/README.md#cdk-and-sso) to set up your dev profile with developer account credentials.
+    > If you get the error message *Unable to resolve AWS account to use. It must be either configured when you define your CDK or through the environment*, you may need to refresh your IAM Identity Center credentials by running the AWS access portal login command described [here](../1-SDLC-organization/README.md#cdk-and-sso) to set up your dev profile with developer account credentials.
 
 1. Retrieve the CloudFormation ouput called *LandingPageStack.LandingPageUrl* to navigate to your landing page
 

--- a/source/3-landing-page-cicd/README.md
+++ b/source/3-landing-page-cicd/README.md
@@ -61,45 +61,45 @@ If you followed the whole [SDLC Organization CDK app](../1-SDLC-organization/REA
 
 Right now, the *Developer* user that you are using has no access to the CICD account as it is only member of the *Developers* group. Let's add it to the **DevOpsEngineers** group to give it access to the CICD account with the appropriate permissions.
 
-1. Navigate to your SSO portal Url and sign in with your *administrator* user
+1. Navigate to your AWS access portal Url and sign in with your *administrator* user
 
-    ![SSO portal sign in page with administrator filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-1.png)
+    ![AWS access portal sign in page with administrator filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-1.png)
 
 1. Click on the AWS Account card
 
-    ![The home page of the SSO portal with the AWS Account card](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-2.png)
+    ![The home page of the AWS access portal with the AWS Account card](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-2.png)
 
 1. Click on the *main* account row to expand it
 
-    ![The home page of the SSO portal with the AWS Account card and the list of account expanded](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-3.png)
+    ![The home page of the AWS access portal with the AWS Account card and the list of account expanded](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-3.png)
 
 1. Click on the *Management console* link for the **AdministratorAccess** permission set
 
-    ![The home page of the SSO portal with the AWS Account card and the list of account expanded and the list of permission set for the main account expanded](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-4.png)
+    ![The home page of the AWS access portal with the AWS Account card and the list of account expanded and the list of permission set for the main account expanded](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-4.png)
 
-1. Seach for the AWS SSO service thanks to the Find Services field
+1. Search for the Identity Center service thanks to the Find Services field
 
-    ![The AWS Console home page with SSO entered in the Find Services field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-5.png)
+    ![The AWS Console home page with Identity Center entered in the Find Services field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-5.png)
 
 1. Click on Users on the left side menu
 
-    ![The AWS SSO Console home page](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-6.png)
+    ![The AWS IAM Identity Center Console home page](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-6.png)
 
 1. Click on the Developer user
 
-    ![The AWS SSO Console Users page with the list of SSO users](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-7.png)
+    ![The AWS IAM Identity Center Console Users page with the list of users](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-7.png)
 
 1. Click on the Groups tab
 
-    ![The AWS SSO Console Users details page for the Developer user](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-8.png)
+    ![The AWS IAM Identity Center Console Users details page for the Developer user](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-8.png)
 
 1. Select the **DevOpsEngineers** group and click on the *Add to 1 group(s)* button
 
-    ![The AWS SSO Console Add user to groups page with the list of available groups](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-10.png)
+    ![The AWS IAM Identity Center Console Add user to groups page with the list of available groups](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-10.png)
 
-1. Go back to your SSO portal and click on *Sign out*
+1. Go back to your AWS access portal and click on *Sign out*
 
-    ![The home page of the SSO portal](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-11.png)
+    ![The home page of the AWS access portal](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-11.png)
 
 </details>
 
@@ -109,15 +109,15 @@ Right now, the *Developer* user that you are using has no access to the CICD acc
 
 1. When you are asked to sign in in a web browser, use your Developer credentials
 
-    ![SSO portal sign in page with Developer filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-13.png)
+    ![AWS access portal sign in page with Developer filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-13.png)
 
 1. Click on the *Sign in to AWS CLI* button
 
-    ![SSO portal sign in page for the AWS CLI sign in](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-14.png)
+    ![AWS access portal sign in page for the AWS CLI sign in](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-14.png)
 
 1. You can close your browser
 
-    ![SSO portal sign in page for the AWS CLI sign in with a confirmation message](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-15.png)
+    ![AWS access portal sign in page for the AWS CLI sign in with a confirmation message](../../doc/landing-page-with-cicd-add-to-devopsengineers-group-15.png)
 
 1. Go back to your shell and select the CICD account
 
@@ -129,7 +129,7 @@ Right now, the *Developer* user that you are using has no access to the CICD acc
 
 1. Execute `npm install -g cdk-sso-sync`
 
-    > Right now the cdk cli is not SSO friendly so we use a small command line tool to synchronize SSO credential with standard aws cli credential so that cdk can use a SSO profile
+    > Right now the cdk cli is not IAM Identity Center friendly so we use a small command line tool to synchronize IAM Identity Center credential with standard aws cli credential so that cdk can use a IAM Identity Center enabled profile
 
 1. Execute `cdk-sso-sync cicd`
 
@@ -203,21 +203,21 @@ git push
 
 <summary>Click to expand</summary>
 
-1. Navigate to your SSO portal Url and sign in with your *Developer* user
+1. Navigate to your AWS access portal Url and sign in with your *Developer* user
 
-    ![SSO portal sign in page with Devloper filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-check-deployment-1.png)
+    ![AWS access portal sign in page with Devloper filled in the username field and some masked characters in the password field](../../doc/landing-page-with-cicd-check-deployment-1.png)
 
 1. Click on the AWS Account card
 
-    ![The home page of the SSO portal with the AWS Account card](../../doc/landing-page-with-cicd-check-deployment-2.png)
+    ![The home page of the AWS access portal with the AWS Account card](../../doc/landing-page-with-cicd-check-deployment-2.png)
 
 1. Click on the *Dev* account row to expand it
 
-    ![The home page of the SSO portal with the AWS Account card and the list of account expanded](../../doc/landing-page-with-cicd-check-deployment-3.png)
+    ![The home page of the AWS access portal with the AWS Account card and the list of account expanded](../../doc/landing-page-with-cicd-check-deployment-3.png)
 
 1. Click on the *Management console* link for the **DevOpsAccess** permission set
 
-    ![The home page of the SSO portal with the AWS Account card and the list of account expanded and the list of permission set for the Dev account expanded](../../doc/landing-page-with-cicd-check-deployment-4.png)
+    ![The home page of the AWS access portal with the AWS Account card and the list of account expanded and the list of permission set for the Dev account expanded](../../doc/landing-page-with-cicd-check-deployment-4.png)
 
 1. Seach for the AWS CodePipeline service thanks to the Find Services field
 
@@ -231,9 +231,9 @@ git push
 
     ![The AWS CodePipeline Console pipeline details page](../../doc/landing-page-with-cicd-check-deployment-7.png)
 
-1. Navigate to your SSO portal and click on the *Staging* row to expand it, and click on the *Management console* link for the *ViewOnly* permission set
+1. Navigate to your AWS access portal and click on the *Staging* row to expand it, and click on the *Management console* link for the *ViewOnly* permission set
 
-    ![The home page of the SSO portal with the AWS Account card and the list of account expanded and the list of permission set for the Staging account expanded](../../doc/landing-page-with-cicd-check-deployment-8.png)
+    ![The home page of the AWS access portal with the AWS Account card and the list of account expanded and the list of permission set for the Staging account expanded](../../doc/landing-page-with-cicd-check-deployment-8.png)
 
 1. Seach for the AWS CloudFormation service thanks to the Find Services field
 

--- a/source/4-landing-page-with-feedback-api/README.md
+++ b/source/4-landing-page-with-feedback-api/README.md
@@ -423,7 +423,7 @@ In the same directory as the stack we created the code for the Lambda function.
     ```
 Deployed the CDK app into our dev account.
 
-1. Went to the directory with your CDK stack, login using SSO and deploy the stack.
+1. Went to the directory with your CDK stack, login using IAM Identity Center and deploy the stack.
 
     ```bash
     $ aws sso login --profile dev

--- a/source/4-landing-page-with-feedback-api/infrastructure/README.md
+++ b/source/4-landing-page-with-feedback-api/infrastructure/README.md
@@ -422,7 +422,7 @@ In the same directory as the stack we created the code for the Lambda function.
     ```
 Deployed the CDK app into our dev account.
 
-1. Went to the directory with your CDK stack, login using SSO and deploy the stack.
+1. Went to the directory with your CDK stack, login using IAM Identity Center and deploy the stack.
 
     ```bash
     $ aws sso login --profile dev

--- a/source/per-stage-dns/README.md
+++ b/source/per-stage-dns/README.md
@@ -85,7 +85,7 @@ This example is a simple CDK app enabling to create the public hosted zones in e
 1. Delegate this dev domain to route53
     Go to your DNS provider and copy the NS records you got from 
         
-    * your different deployed stack in each environment by going to SSO Login page > Staging or Prod Account ReadOnly access > AWS Console > Cloud Formation > DNS-Infrastructure > Outputs > NSrecords 
+    * your different deployed stack in each environment by going to AWS access portal Login page > Staging or Prod Account ReadOnly access > AWS Console > Cloud Formation > DNS-Infrastructure > Outputs > NSrecords 
     
     * or running this command against each stage (if you configured your aws profile properly, `prod` is the one use in this example): `aws cloudformation describe-stacks --stack-name DNS-Infrastructure --query "Stacks[0].Outputs[?OutputKey=='NSrecords'].OutputValue" --output text --profile prod`
 
@@ -96,7 +96,7 @@ This example is a simple CDK app enabling to create the public hosted zones in e
 
 1. You will need the coresponding zone id so we suggest that you create the same kind of mapping done in this app `cdk.json` but with the coresponding zoneId:
     1. Get the zoneId from the different stages:
-        * your different deployed stack in each environment by going to SSO Login page > Staging or Prod Account ReadOnly access > AWS Console > Cloud Formation > DNS-Infrastructure > Outputs > HostedZoneId
+        * your different deployed stack in each environment by going to AWS access portal Login page > Staging or Prod Account ReadOnly access > AWS Console > Cloud Formation > DNS-Infrastructure > Outputs > HostedZoneId
         * running this command for dev
         ```
         aws cloudformation describe-stacks --stack-name DNS-Infrastructure --query "Stacks[0].Outputs[?OutputKey=='HostedZoneId'].OutputValue" --output text --profile dev


### PR DESCRIPTION
*Description of changes:*

The AWS SSO (Single-Sign-On) service was renamed to [AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html). This PR updates the README files to reflect this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
